### PR TITLE
fix: changed to use system's default python interpreter

### DIFF
--- a/src/ci_server.py
+++ b/src/ci_server.py
@@ -4,6 +4,8 @@ import requests
 import subprocess
 import os
 import shutil
+import sys
+
 
 GITHUB_TOKEN = None
 
@@ -131,7 +133,7 @@ def build_project(path) -> bool:
         print(f"Setting up venv failed: {e.stdout}")
         return False
 
-    command = ["python3", "-m", "py_compile"]
+    command = [sys.executable, "-m", "py_compile"]
     command.extend(files)
     try:
         subprocess.run(command, check=True)


### PR DESCRIPTION
Changed so that the command uses the `sys.executable` variable instead of `"python3"`