### PR TITLE
feat: Implemented build history, closes #18

### DIFF
--- a/src/ci_server.py
+++ b/src/ci_server.py
@@ -8,6 +8,10 @@ import shutil
 import sys
 from threading import Thread
 
+import sqlite3
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+from db import *
+import datetime
 
 load_dotenv()
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
@@ -15,6 +19,24 @@ GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 app = Flask(__name__)
 
 CLONE_DIR = "/tmp/"  # Temporary directory to clone the repo into
+
+
+@app.route("/builds")
+def builds():
+    db = get_db()
+    builds = get_builds(db)
+    close_db()
+    return jsonify(builds), 200
+
+
+@app.route("/build/<int:build_id>", methods=["GET"])
+def build(build_id):
+    db = get_db()
+    build = get_build(db, build_id)
+    close_db()
+    if build is None:
+        return {"error": "Build not found"}, 404
+    return jsonify(build), 200
 
 
 @app.route("/webhook", methods=["POST"])
@@ -87,11 +109,21 @@ def process_request(payload: dict) -> int:
         if build_project(repo_path) and run_tests(repo_path):
             # Success if cloned and successfully built and tested
             update_github_status(status_url, "success", GITHUB_TOKEN)
+            try:
+                db_conn = get_db()
+                insert_build(db_conn, commit_sha, datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'), "success")
+            except sqlite3.Error as e:
+                print("Database error:", e)
             print("message", "Build and tests successful")
             return 200
         else:
             # Failure if cloned but unsuccessfully built or tested
             update_github_status(status_url, "failure", GITHUB_TOKEN)
+            try:
+                db_conn = get_db()
+                insert_build(db_conn, commit_sha, datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'), "failure")
+            except sqlite3.Error as e:
+                print("Database error:", e)
             print("message", "Build/tests failed")
             return 200
 
@@ -316,4 +348,5 @@ def update_github_status(url: str, state: str, github_token: str) -> int:
 
 
 if __name__ == "__main__":
+    initialise_db()
     app.run(host="127.0.0.1", port=5000)

--- a/src/ci_server.py
+++ b/src/ci_server.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, render_template
 import venv
 import requests
 import subprocess
@@ -22,21 +22,20 @@ CLONE_DIR = "/tmp/"  # Temporary directory to clone the repo into
 
 
 @app.route("/builds")
-def builds():
+def builds_view():
     db = get_db()
     builds = get_builds(db)
     close_db()
-    return jsonify(builds), 200
-
+    return render_template('builds.html', builds=builds)
 
 @app.route("/build/<int:build_id>", methods=["GET"])
-def build(build_id):
+def build_view(build_id):
     db = get_db()
     build = get_build(db, build_id)
     close_db()
     if build is None:
         return {"error": "Build not found"}, 404
-    return jsonify(build), 200
+    return render_template('build.html', build=build)
 
 
 @app.route("/webhook", methods=["POST"])

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,69 @@
+import sqlite3
+from flask import g
+
+DATABASE = "ci_server.db"
+
+
+# Initialise the database
+def initialise_db():
+    try:
+        conn = sqlite3.connect(DATABASE)
+
+        # Create the table if it doesn't exist
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS builds (
+                id INTEGER PRIMARY KEY,
+                commit_identifier TEXT NOT NULL,
+                build_date TEXT NOT NULL,
+                status TEXT not null
+            )
+        """
+        )
+        conn.commit()
+        return conn
+
+    except sqlite3.Error as e:
+        print("Database error:", e)
+        return None
+
+
+def get_db():
+    if "db" not in g:
+        g.db = sqlite3.connect(DATABASE)
+    return g.db
+
+
+def close_db():
+    db = g.pop("db", None)
+    if db is not None:
+        db.close()
+
+
+# Insert a new build record
+def insert_build(conn, commit_identifier, build_date, status):
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO builds (commit_identifier, build_date, status)
+        VALUES (?, ?, ?)
+    """,
+        (commit_identifier, build_date, status),
+    )
+    conn.commit()
+    return cursor.lastrowid
+
+
+# Get all build records
+def get_builds(conn):
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM builds")
+    return cursor.fetchall()
+
+
+# Get a specific build record
+def get_build(conn, build_id):
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM builds WHERE id = ?", (build_id,))
+    return cursor.fetchone()

--- a/src/templates/build.html
+++ b/src/templates/build.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>CI Server</title>
+    <style>
+        body {
+            margin: 20px;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>Build Details</h1>
+    {% if build %}
+    <div class="detail">
+        <span class="label">ID:</span> {{ build[0] }}
+    </div>
+    <div class="detail">
+        <span class="label">Commit Identifier:</span> {{ build[1] }}
+    </div>
+    <div class="detail">
+        <span class="label">Build Date:</span> {{ build[2] }}
+    </div>
+    {% if build|length > 3 %}
+    <div class="detail">
+        <span class="label">Status:</span> {{ build[3] }}
+    </div>
+    {% endif %}
+    {% else %}
+    <p>No build information available.</p>
+    {% endif %}
+</body>
+
+</html>

--- a/src/templates/builds.html
+++ b/src/templates/builds.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>CI Server</title>
+    <style>
+        body {
+            margin: 20px;
+        }
+
+        table {
+            border-collapse: collapse;
+            width: 80%;
+        }
+
+        th,
+        td {
+            border: 1px solid #ccc;
+            padding: 10px;
+            text-align: left;
+        }
+
+        th {
+            background-color: #f0f0f0;
+        }
+
+        tr.clickable {
+            cursor: pointer;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>Builds</h1>
+    {% if builds %}
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Commit Identifier</th>
+                <th>Build Date</th>
+                {% if builds[0]|length > 3 %}
+                <th>Status</th>
+                {% endif %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for build in builds|reverse %}
+            <tr class="clickable" onclick="window.location.href='/build/{{ build[0] }}'">
+                <td>{{ build[0] }}</td>
+                <td>{{ build[1] }}</td>
+                <td>{{ build[2] }}</td>
+                {% if build|length > 3 %}
+                <td>{{ build[3] }}</td>
+                {% endif %}
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p>No builds available.</p>
+    {% endif %}
+</body>
+
+</html>

--- a/tests/test_ci_server.py
+++ b/tests/test_ci_server.py
@@ -56,15 +56,26 @@ def test_handle_webhook(
     assert response.status_code == 200
 
 
+@patch("ci_server.insert_build")
+@patch("ci_server.get_db")
 @patch("ci_server.clone_repo")
 @patch("ci_server.build_project")
 @patch("ci_server.run_tests")
 @patch("ci_server.update_github_status")
-def test_process_request(mock_update_status, mock_run_tests, mock_build, mock_clone):
+def test_process_request(
+    mock_update_status,
+    mock_run_tests,
+    mock_build,
+    mock_clone,
+    mock_get_db,
+    mock_insert_build,
+):
     # Passing commit
     mock_clone.return_value = (True, "/repo/path")
     mock_build.return_value = True
     mock_run_tests.return_value = True
+    mock_get_db.return_value = "db_connection"
+    mock_insert_build.return_value = 1
 
     payload = {
         "repository": {

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,89 @@
+import pytest
+import sys
+import os
+import sqlite3
+import pytest
+from flask import Flask, g
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+from db import *
+
+@pytest.fixture
+def app_context(tmp_path, monkeypatch):
+    # Create a Flask app.
+    app = Flask(__name__)
+
+    # Use a temporary file as the database.
+    temp_db_path = tmp_path / "test_ci_server.db"
+    monkeypatch.setattr("db.DATABASE", str(temp_db_path))
+
+    # Push an application context so that `g` is available.
+    with app.app_context():
+        # Initialise the database (this will create the schema in temp_db_path)
+        initialise_db()
+        yield app
+        # The temporary directory will be automatically cleaned up by pytest.
+
+# test initialise_db
+def test_initialise_db(tmp_path, monkeypatch):
+    # Use a separate temporary database file.
+    temp_db_path = tmp_path / "init_test.db"
+    monkeypatch.setattr("db.DATABASE", str(temp_db_path))
+    conn = initialise_db()
+    # Check that the file was created.
+    assert os.path.exists(str(temp_db_path))
+    
+    # Verify that the 'builds' table exists.
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='builds';"
+    )
+    table = cursor.fetchone()
+    assert table is not None
+    conn.close()
+
+
+# test helper functions
+def test_insert_and_query_builds(app_context):
+    # Get a connection from the request context.
+    db_conn = get_db()
+    assert isinstance(db_conn, sqlite3.Connection)
+
+    # Insert a new build record.
+    commit_identifier = "abc123"
+    build_date = "2023-10-10"
+    status = "success"
+    build_id = insert_build(db_conn, commit_identifier, build_date, status)
+    assert isinstance(build_id, int)
+
+    # Retrieve all build records.
+    builds = get_builds(db_conn)
+    # We expect one record.
+    assert len(builds) == 1
+    # SQLite returns rows as tuples: (id, commit_identifier, build_date)
+    row = builds[0]
+    assert row[0] == build_id
+    assert row[1] == commit_identifier
+    assert row[2] == build_date
+
+    # Retrieve the specific build by its ID.
+    build = get_build(db_conn, build_id)
+    assert build is not None
+    assert build[0] == build_id
+    assert build[1] == commit_identifier
+    assert build[2] == build_date
+
+
+def test_close_db(app_context):
+    # Create a DB connection.
+    db_conn = get_db()
+    assert db_conn is not None
+    # Close it.
+    close_db()
+    # Confirm that 'db' is no longer in the Flask global `g`.
+    assert "db" not in g
+
+    # If we ask for the connection again, a new one should be created.
+    new_db_conn = get_db()
+    assert new_db_conn is not None
+    assert new_db_conn != db_conn


### PR DESCRIPTION
The CI server keeps the history of the past builds. This history persists even if the server is rebooted. Each build is given a unique URL, that is accessible to get the build information (commit identifier, build date, build logs). One URL exists to list all builds.