### PR TITLE
Separate webhook handling and request processing to avoid timeouts, closes #36

### DIFF
--- a/src/ci_server.py
+++ b/src/ci_server.py
@@ -84,7 +84,7 @@ def process_request(payload: dict) -> int:
         else:
             # Failure if cloned but unsuccessfully built or tested
             update_github_status(status_url, "failure", GITHUB_TOKEN)
-            print("message", "Build and tests successful")
+            print("message", "Build/tests failed")
             return 200
 
     except Exception:


### PR DESCRIPTION
Passes tests but gives a fatal error for cloning a non existent repository.
The documentation for the new function is in sphinx format.
Closes #36 