### PR TITLE
Add mocking for process request, passes tests, closes #55

### DIFF
--- a/tests/test_ci_server.py
+++ b/tests/test_ci_server.py
@@ -21,13 +21,15 @@ def client():
     return app.test_client()
 
 
+@patch("ci_server.process_request")
 @patch("ci_server.clone_repo")
 @patch("ci_server.build_project")
 @patch("ci_server.run_tests")
 @patch("ci_server.update_github_status")
 def test_handle_webhook(
-    mock_update_status, mock_run_tests, mock_build, mock_clone, client
+    mock_update_status, mock_run_tests, mock_build, mock_clone, mock_process, client
 ):
+    mock_process.return_value = 200
     # Invalid event
     headers = {"X-GitHub-Event": "push", "Content-Type": "application/json"}
 


### PR DESCRIPTION
This did not pass tests locally on my PC since I got this message during the clone repo tests
`Permission denied: Could not delete /tmp/Continuous-Integration-Server-abcd1234`
However it does pass serverside.
Closes #55 